### PR TITLE
Fix missing brace when WIRE1_SUPPORT not defined

### DIFF
--- a/AS1115.cpp
+++ b/AS1115.cpp
@@ -213,8 +213,8 @@ byte AS1115::as1115WriteRegister(byte reg, byte val, byte write_addr) {
     Wire1.write(reg);
     Wire1.write(val);
     return Wire1.endTransmission();
-  }
 #endif
+  }
 }
 
 byte AS1115::as1115WriteRegister(byte reg, byte val) {


### PR DESCRIPTION
The closing brace was placed inside the preprocessor conditional statement, which caused compilation to fail when `WIRE1_SUPPORT` was not defined:
```
E:\arduino\libraries\arduino-as1115\AS1115.cpp: In member function 'byte AS1115::as1115WriteRegister(byte, byte, byte)':

E:\arduino\libraries\arduino-as1115\AS1115.cpp:220:33: error: qualified-id in declaration before '(' token

 byte AS1115::as1115WriteRegister(byte reg, byte val) {
```
Fixes https://github.com/sarahemm/arduino-as1115/issues/4

CC: @Lhburch